### PR TITLE
Exported OMInputStream prototypes

### DIFF
--- a/lib/ometajs/core.js
+++ b/lib/ometajs/core.js
@@ -79,6 +79,7 @@ function OMInputStream(hd, tl) {
   this.hd   = hd
   this.tl   = tl
 };
+exports.OMInputStream = OMInputStream;
 
 //
 // ### function head ()
@@ -124,6 +125,7 @@ function OMInputStreamEnd(lst, idx) {
   this.lst = lst
   this.idx = idx
 };
+exports.OMInputStreamEnd = OMInputStreamEnd;
 OMInputStreamEnd.prototype = objectThatDelegatesTo(OMInputStream.prototype);
 
 //
@@ -150,6 +152,7 @@ function ListOMInputStream(lst, idx) {
   this.idx  = idx;
   this.hd   = lst[idx];
 }
+exports.ListOMInputStream = ListOMInputStream;
 ListOMInputStream.prototype = objectThatDelegatesTo(OMInputStream.prototype);
 
 //
@@ -179,6 +182,7 @@ function makeListOMInputStream(lst, idx) {
     return new OMInputStreamEnd(lst, idx);
   }
 }
+exports.makeListOMInputStream = makeListOMInputStream;
 
 //
 // ### function makeOMInputStreamProxy (target)
@@ -196,6 +200,7 @@ function makeOMInputStreamProxy(target) {
     }
   })
 }
+exports.makeOMInputStreamProxy = makeOMInputStreamProxy;
 
 //
 // ### function Failer()

--- a/lib/ometajs/core.js
+++ b/lib/ometajs/core.js
@@ -60,7 +60,7 @@ function lookup(fn, success, fallback) {
     value = fn();
   } catch (e) {
     if (!(e instanceof SyntaxError)) throw e;
-    return fallback && fallback();
+    return fallback && fallback(e);
   }
 
   return success && success(value);
@@ -643,7 +643,7 @@ var OMeta = exports.OMeta = {
           m._applyWithArgs.apply(m, realArgs);
     }, function(value) {
       return value;
-    }, function() {
+    }, function(err) {
       if (matchFailed != undefined) {
         var input = m.input
         if (input.idx != undefined) {
@@ -651,7 +651,7 @@ var OMeta = exports.OMeta = {
             input = input.tl
           input.idx--
         }
-        return matchFailed(m, input.idx)
+        return matchFailed(m, input.idx, err)
       }
       throw f
     });


### PR DESCRIPTION
Required access to OMInputStream types to create an alternative input
stream option.

Sergey & Indutny — thanks for spearheading the effort to tidy up the ometajs code for more production oriented use.  I'm extending OMeta in another library for use with different InputStream objects, and it was so much easier to use your modularized version.  This change just exports a few more objects from Core that I needed to access.  I'll be looking forward to your rewrite version!
Thanks,
-Shane
