### PR TITLE
Implement foreign rules

### DIFF
--- a/lib/ometajs/core/grammar.js
+++ b/lib/ometajs/core/grammar.js
@@ -265,6 +265,19 @@ AbstractGrammar.prototype._rule = function rule(name,
         }
       });
     }
+  } else if(name == 'foreign') {
+    var p = new(args[0])(this._source);
+    p._offset = this._offset;
+    res = p._rule(args[1], false, args.slice(2));
+    if(res) {
+      this._offset = p._offset;
+      this._source = p._source;
+    } else {
+      this._errorRule = args[0].constructor.name + '.' + args[1];
+      this._errorHistory = p._history;
+      this._errorOffset = p._offset;
+      this._errorSource = p._source;
+    }
   } else {
     res = this._invoke(cons || this.constructor, name, body, nocache, args);
   }


### PR DESCRIPTION
Fixes #17

This adds a magic rule called foreign and adds it to the compiler.

I couldn't figure out what to do with super rules.
