### PR TITLE
Correctly report error locations

### DIFF
--- a/lib/ometajs/core/grammar.js
+++ b/lib/ometajs/core/grammar.js
@@ -78,6 +78,7 @@ AbstractGrammar.prototype._getError = function getError(errback) {
         prev = '',
         preprev = '',
         lineNumber = 0,
+        colNumber = 0,
         offset = 0,
         current = 0,
         error = this._errorStack || new Error();
@@ -98,14 +99,17 @@ AbstractGrammar.prototype._getError = function getError(errback) {
           return false;
         }
 
-        offset = this._errorOffset - current;
+        // offsets are 0-based, columns are 1-based
+        colNumber = this._errorOffset - current + 1; 
         line = source;
-        lineNumber = i;
+        // i is 0-based, line number is 1-based
+        lineNumber = i + 1; 
 
         return true;
       }, this);
 
 
+      offset = colNumber;
       if (line.length > 80) {
         var suboffset = Math.max(0, offset - 10);
         line = line.slice(suboffset, Math.min(suboffset + 70, line.length));
@@ -114,13 +118,13 @@ AbstractGrammar.prototype._getError = function getError(errback) {
       line = line.replace(/\t/g, ' ');
 
       error.message = this._errorRule + ' rule failed at: ' +
-                      lineNumber + ':' + offset + '\n' +
+                      lineNumber + ':' + colNumber + '\n' +
                       preprev + '\n' +
                       prev + '\n' +
                       line + '\n' +
-                      new Array(offset + 1).join(' ') + '^';
+                      new Array(offset).join(' ') + '^';
       error.line = lineNumber;
-      error.offset = offset;
+      error.column = colNumber;
     }
 
     errback(error);

--- a/test/unit/functional-test.js
+++ b/test/unit/functional-test.js
@@ -28,6 +28,29 @@ suite('Ometajs module', function() {
     });
   });
 
+  suite('parse errors', function() {
+    function testErrorReport(expr, line, column, done) {
+      var grmr = common.require('lr').LeftRecursion,
+          g = new grmr(expr);
+
+      g._rule('expr');
+      g._getError(function(error) {
+          assert.equal(error.line, line);
+          assert.equal(error.column, column);
+          done();
+      });
+    }
+
+    test('should be reported correctly for short lines', function(done) {
+        testErrorReport('123 ^ 2', 1, 5, done);
+    });
+
+    test('should be reported correctly for long lines lines', function(done) {
+        var line = '123' + new Array(80).join(' ') + '^';
+        testErrorReport(line, 1, 83, done);
+    });
+  });
+
   suite('given a grammar with local statement', function() {
     var grmr = common.require('local').Local;
 


### PR DESCRIPTION
Line is reported using 1-based indexing.
Column is reported instead of offset and does not gets reduced
when line is longer 80 characters.

@veged @arikon @indutny
