### PR TITLE
Add parser-test with mixed-type args passed to super call

### DIFF
--- a/test/unit/parser-test.js
+++ b/test/unit/parser-test.js
@@ -349,17 +349,16 @@ suite('Ometajs language parser', function() {
         );
       });
 
-      test('super invocation with args', function() {
-        // XXX: Why 1, 2, 3 are parsing to strings?
+      test('super invocation with mixed-type args', function() {
         unit(
-          'ometa name { rule ^rule(1, 2, 3) }',
+          'ometa name { rule ^rule(1, #2, 3) }',
           [ [
             'grammar',
             'name',
             null,
             [ [
               'rule', 'rule', [
-                [ 'super', [ 'call', null, 'rule', [ '1', '2', '3' ] ] ]
+                [ 'super', [ 'call', null, 'rule', [ '1', '"2"', '3' ] ] ]
             ]
             ] ]
           ] ]


### PR DESCRIPTION
Test confirms that the parser preserves the types of arguments passed to rule invocations.
