### PR TITLE
protect from missing require when in browser

### DIFF
--- a/lib/ometajs/api.js
+++ b/lib/ometajs/api.js
@@ -21,6 +21,7 @@ api.compile = function compile(code, options) {
 //
 // Allow require('filename.ometajs')
 //
+if(require && require.extensions) { //protection for browser usage
 require.extensions['.ometajs'] = function loadExtension(module, filename) {
   var content = fs.readFileSync(filename).toString(),
       source = api.compile(content, {
@@ -29,3 +30,4 @@ require.extensions['.ometajs'] = function loadExtension(module, filename) {
 
   module._compile(source, filename);
 };
+}

--- a/lib/ometajs/api.js
+++ b/lib/ometajs/api.js
@@ -21,7 +21,7 @@ api.compile = function compile(code, options) {
 //
 // Allow require('filename.ometajs')
 //
-if(typeof require !== undefined && typeof require.extensions !== undefined) { //protection for browser usage
+if(typeof require !== 'undefined' && typeof require.extensions !== 'undefined') { //protection for browser usage
 require.extensions['.ometajs'] = function loadExtension(module, filename) {
   var content = fs.readFileSync(filename).toString(),
       source = api.compile(content, {

--- a/lib/ometajs/api.js
+++ b/lib/ometajs/api.js
@@ -21,7 +21,7 @@ api.compile = function compile(code, options) {
 //
 // Allow require('filename.ometajs')
 //
-if(require && require.extensions) { //protection for browser usage
+if(typeof require !== undefined && typeof require.extensions !== undefined) { //protection for browser usage
 require.extensions['.ometajs'] = function loadExtension(module, filename) {
   var content = fs.readFileSync(filename).toString(),
       source = api.compile(content, {


### PR DESCRIPTION
I'm using ometa-js on both server and client. For client I'm bundling it up with browserify, but ometa-js fails because of the extensions hook.  This patch skips the hook if the 'require' function doesn't exist.
