### PR TITLE
return false when rule not found

### DIFF
--- a/lib/ometajs/core/grammar.js
+++ b/lib/ometajs/core/grammar.js
@@ -165,8 +165,8 @@ AbstractGrammar.prototype._invoke = function _invoke(grmr, rule, fn, nc, args) {
     this._result = undefined;
 
     // Invoke actual rule function
-    if (body === undefined)
-      throw new Error('Rule: ' + rule + ' not found!');
+    if (body === undefined) return false;
+      // throw new Error('Rule: ' + rule + ' not found!');
     return body.call(this);
   }
 


### PR DESCRIPTION
@indutny throwing when rule not found appears to change semantics and
break things. No idea why and I can't give you a small enough case.
Returing false is what it used to do before. I assume failure to find a
rule is a legit way for match to fail and backtrack. Could you pls check it. Thx

Maybe some reporting is warranted here if only for debugging, like pushing `'Rule: ' + rule + ' not found'` on some error stack to report in case backtracking fails.
